### PR TITLE
Handle function references properly

### DIFF
--- a/lib/exavier.ex
+++ b/lib/exavier.ex
@@ -114,6 +114,17 @@ defmodule Exavier do
     {mutated_lines_body_rest, [{operator, mutated_body} | mutated_rest]}
   end
 
+  def mutate_all({:&, meta, args} = ast, mutator, lines_to_mutate, already_mutated_lines) do
+    case Enum.member?(lines_to_mutate, meta[:line]) do
+      true ->
+        {already_mutated_lines, ast}
+      _ ->
+        {mutated_lines, mutated_args} =
+        mutate_all(args, mutator, lines_to_mutate, already_mutated_lines)
+        {mutated_lines, {:&, meta, mutated_args}}
+    end
+  end
+
   def mutate_all(
     {operator, meta, args} = ast, mutator, lines_to_mutate, already_mutated_lines
   ) do

--- a/lib/exavier.ex
+++ b/lib/exavier.ex
@@ -114,15 +114,16 @@ defmodule Exavier do
     {mutated_lines_body_rest, [{operator, mutated_body} | mutated_rest]}
   end
 
-  def mutate_all({:&, meta, args} = ast, mutator, lines_to_mutate, already_mutated_lines) do
-    case Enum.member?(lines_to_mutate, meta[:line]) do
-      true ->
-        {already_mutated_lines, ast}
-      _ ->
-        {mutated_lines, mutated_args} =
-        mutate_all(args, mutator, lines_to_mutate, already_mutated_lines)
-        {mutated_lines, {:&, meta, mutated_args}}
-    end
+  def mutate_all({:&, meta, args} = _ast, mutator, lines_to_mutate, already_mutated_lines) do
+    current_line = meta[:line]
+    {mutated_lines, mutated_args} =
+      case Enum.member?(lines_to_mutate, current_line) do
+        true ->
+          mutate_all(args, mutator, List.delete(lines_to_mutate, current_line), [current_line | already_mutated_lines])
+        _ ->
+          mutate_all(args, mutator, lines_to_mutate, already_mutated_lines)
+        end
+    {mutated_lines, {:&, meta, mutated_args}}
   end
 
   def mutate_all(

--- a/lib/foo_bar.ex
+++ b/lib/foo_bar.ex
@@ -1,3 +1,7 @@
 defmodule FooBar do
   def sub(a, b), do: a - b
+
+  def list_sum(list), do: Enum.reduce(list, 0, &add/2)
+
+  defp add(a, b), do: a + b
 end

--- a/lib/foo_bar.ex
+++ b/lib/foo_bar.ex
@@ -1,7 +1,11 @@
 defmodule FooBar do
   def sub(a, b), do: a - b
 
-  def list_sum(list), do: Enum.reduce(list, 0, &add/2)
+  def list_sum(list) do
+    Enum.reduce(list, 0, &add/2)
+  end
+
+  def div(a, b) when b != 0, do: a / b
 
   defp add(a, b), do: a + b
 end

--- a/test/foo_bar_test.exs
+++ b/test/foo_bar_test.exs
@@ -3,7 +3,11 @@ defmodule FooBarTest do
 
   @subject FooBar
 
-  test "when 0, 0" do
+  test "when 0, sub 0" do
     assert @subject.sub(0, 0) == 0
+  end
+
+  test "when [1, 2, 3], list_sum 6" do
+    assert @subject.list_sum([1, 2, 3]) == 6
   end
 end

--- a/test/foo_bar_test.exs
+++ b/test/foo_bar_test.exs
@@ -10,4 +10,8 @@ defmodule FooBarTest do
   test "when [1, 2, 3], list_sum 6" do
     assert @subject.list_sum([1, 2, 3]) == 6
   end
+
+  test "when one number is negative" do
+    assert @subject.div(100, -20) == -5
+  end
 end


### PR DESCRIPTION
Fixes [this](https://github.com/dnlserrano/exavier/issues/2) issue.
We now mutate `:/` operator only in case when it's an arithmetic operator.