### PR TITLE
Add NegateConditionals mutator

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,17 @@ The `exavier` library mutates code in **parallel per module**, but mutates each 
 
 ### Mutators
 
-Mutators specify ways in which we can mutate the code. Currently we have 5 proof-of-concept mutators available in `exavier`:
+Mutators specify ways in which we can mutate the code. Currently we have 6 proof-of-concept mutators available in `exavier`:
 
   - [AOR1](https://github.com/dnlserrano/exavier/blob/master/lib/exavier/mutators/aor1.ex)
   - [AOR2](https://github.com/dnlserrano/exavier/blob/master/lib/exavier/mutators/aor2.ex)
   - [ROR1](https://github.com/dnlserrano/exavier/blob/master/lib/exavier/mutators/ror1.ex)
   - [ROR4](https://github.com/dnlserrano/exavier/blob/master/lib/exavier/mutators/ror4.ex)
   - [IfTrue](https://github.com/dnlserrano/exavier/blob/master/lib/exavier/mutators/if_true.ex)
+  - [NegateConditionals](https://github.com/dnlserrano/exavier/blob/master/lib/exavier/mutators/negate_conditionals.ex)
 
 `AOR` stands for "Arithmetic Operator Replacement". There are several possibilities for replacing an arithmetic operator. We follow the ones defined by [`pitest`](http://pitest.org/quickstart/mutators/#available-mutators-and-groups). Similarly, `ROR` stands for "Relational Operator Replacement". `IfTrue` is inspired by `pitest`'s "Remove Conditionals".
+`NegateConditionals` is also inspired by `pitest`.
 
 You can create new mutators. You just have to make sure they abide to the interface provided by behaviour [`Exavier.Mutators.Mutator`](https://github.com/dnlserrano/exavier/blob/master/lib/exavier/mutators/mutator.ex):
 
@@ -154,7 +156,7 @@ This is for now just a proof-of-concept. A lot of it has been no more than a joy
   - [x] [Remove Conditionals](http://pitest.org/quickstart/mutators/#REMOVE_CONDITIONALS)
     - Can still be done for `case`, `unless`
   - [ ] [Conditionals Boundary](http://pitest.org/quickstart/mutators/#CONDITIONALS_BOUNDARY)
-  - [ ] [Negate Conditionals](http://pitest.org/quickstart/mutators/#NEGATE_CONDITIONALS)
+  - [x] [Negate Conditionals](http://pitest.org/quickstart/mutators/#NEGATE_CONDITIONALS)
   - [ ] [Invert Negatives](http://pitest.org/quickstart/mutators/#INVERT_NEGS)
 - [ ] Ability to tune which mutators are used
 - [ ] Ability to add custom mutators defined by the user (i.e., not in `exavier`)

--- a/lib/exavier/mutators.ex
+++ b/lib/exavier/mutators.ex
@@ -4,7 +4,8 @@ defmodule Exavier.Mutators do
     __MODULE__.AOR2,
     __MODULE__.ROR1,
     __MODULE__.ROR4,
-    __MODULE__.IfTrue
+    __MODULE__.IfTrue,
+    __MODULE__.NegateConditionals
   ]
 
   def operators do

--- a/lib/exavier/mutators/negate_conditionals.ex
+++ b/lib/exavier/mutators/negate_conditionals.ex
@@ -1,0 +1,59 @@
+defmodule Exavier.Mutators.NegateConditionals do
+  @moduledoc """
+  Mutates conditional operators into their opposite.
+
+  Conditionals are replaced according to the table below.
+
+  | Original | Mutation |
+  |----------|----------|
+  | ==       | !=       |
+  | !=       | ==       |
+  | <=       | >        |
+  | >=       | <        |
+  | <        | >=       |
+  | >        | <=       |
+
+  For example:
+
+      if a == b {
+        // do something
+      }
+
+  will be mutated into
+
+      if a != b {
+        // do something
+      }
+  """
+
+  @behaviour Exavier.Mutators.Mutator
+
+  @mutations %{
+    :== => :!=,
+    :!= => :==,
+    :<= => :>,
+    :>= => :<,
+    :< => :>=,
+    :> => :<=
+  }
+
+  @impl Exavier.Mutators.Mutator
+  def operators, do: Map.keys(@mutations)
+
+  @impl Exavier.Mutators.Mutator
+  def mutate({operator, meta, args}, lines_to_mutate) do
+    mutated_operator = mutate_operator(operator, args)
+    do_mutate({mutated_operator, meta, args}, lines_to_mutate)
+  end
+
+  defp mutate_operator(:-, args) when length(args) == 1, do: :-
+
+  defp mutate_operator(operator, _args), do: @mutations[operator]
+
+  defp do_mutate({nil, _, _}, _), do: :skip
+
+  defp do_mutate({mutated_op, meta, args}, lines_to_mutate) do
+    {_, mutated_args} = Exavier.mutate_all(args, __MODULE__, lines_to_mutate)
+    {mutated_op, meta, mutated_args}
+  end
+end

--- a/test/exavier/mutators/negate_conditionals_test.exs
+++ b/test/exavier/mutators/negate_conditionals_test.exs
@@ -1,0 +1,63 @@
+defmodule Exavier.Mutators.NegateConditionalsTest do
+  use ExUnit.Case, async: true
+
+  @subject Exavier.Mutators.NegateConditionals
+
+  @mutations [
+    %{
+      description: "mutates == to !==",
+      original_code: {:==, [line: 2], [1, 2]},
+      lines_to_mutate: [2],
+      mutated_code: {:!=, [line: 2], [1, 2]}
+    },
+    %{
+      description: "mutates != to ==",
+      original_code: {:!=, [line: 2], [1, 2]},
+      lines_to_mutate: [2],
+      mutated_code: {:==, [line: 2], [1, 2]}
+    },
+    %{
+      description: "mutates <= to >",
+      original_code: {:<=, [line: 2], [1, 2]},
+      lines_to_mutate: [2],
+      mutated_code: {:>, [line: 2], [1, 2]}
+    },
+    %{
+      description: "mutates >= to <",
+      original_code: {:>=, [line: 2], [1, 2]},
+      lines_to_mutate: [2],
+      mutated_code: {:<, [line: 2], [1, 2]}
+    },
+    %{
+      description: "mutates < to >=",
+      original_code: {:<, [line: 2], [1, 2]},
+      lines_to_mutate: [2],
+      mutated_code: {:>=, [line: 2], [1, 2]}
+    },
+    %{
+      description: "mutates > to <=",
+      original_code: {:>, [line: 2], [1, 2]},
+      lines_to_mutate: [2],
+      mutated_code: {:<=, [line: 2], [1, 2]}
+    },
+    %{
+      description: "mutates recursively if operator is repeated",
+      original_code: {:==, [line: 2], [{:<=, [line: 3], [2, 3]}, false]},
+      lines_to_mutate: [2, 3],
+      mutated_code: {:!=, [line: 2], [{:>, [line: 3], [2, 3]}, false]}
+    }
+  ]
+
+  @mutations
+  |> Enum.each(fn mutation ->
+    @original_code mutation.original_code
+    @lines_to_mutate mutation.lines_to_mutate
+    @mutated_code mutation.mutated_code
+    @description mutation.description
+
+    test @description do
+      assert @subject.mutate(@original_code, @lines_to_mutate) ==
+               @mutated_code
+    end
+  end)
+end


### PR DESCRIPTION
It's on the roadmap, and I think it's a very useful mutator.

This change duplicates one of the other operator-replacing mutators and implements it for `==`, `!=`, `<`, `>`, `<=`, and `>=`.