### PR TITLE
Add missing AOR and ROR mutators

### DIFF
--- a/.exavier.exs
+++ b/.exavier.exs
@@ -3,7 +3,11 @@
   test_files_to_modules: %{
     "test/exavier/mutators/aor1_test.exs" => Exavier.Mutators.AOR1,
     "test/exavier/mutators/aor2_test.exs" => Exavier.Mutators.AOR2,
+    "test/exavier/mutators/aor3_test.exs" => Exavier.Mutators.AOR3,
+    "test/exavier/mutators/aor4_test.exs" => Exavier.Mutators.AOR4,
     "test/exavier/mutators/ror1_test.exs" => Exavier.Mutators.ROR1,
+    "test/exavier/mutators/ror2_test.exs" => Exavier.Mutators.ROR2,
+    "test/exavier/mutators/ror3_test.exs" => Exavier.Mutators.ROR3,
     "test/exavier/mutators/ror4_test.exs" => Exavier.Mutators.ROR4
   }
 }

--- a/.exavier.exs
+++ b/.exavier.exs
@@ -8,6 +8,7 @@
     "test/exavier/mutators/ror1_test.exs" => Exavier.Mutators.ROR1,
     "test/exavier/mutators/ror2_test.exs" => Exavier.Mutators.ROR2,
     "test/exavier/mutators/ror3_test.exs" => Exavier.Mutators.ROR3,
-    "test/exavier/mutators/ror4_test.exs" => Exavier.Mutators.ROR4
+    "test/exavier/mutators/ror4_test.exs" => Exavier.Mutators.ROR4,
+    "test/exavier/mutators/ror5_test.exs" => Exavier.Mutators.ROR5
   }
 }

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ This is for now just a proof-of-concept. A lot of it has been no more than a joy
   - [x] [AOR3](http://pitest.org/quickstart/mutators/#AOR)
   - [x] [AOR4](http://pitest.org/quickstart/mutators/#AOR)
   - [x] [ROR1](http://pitest.org/quickstart/mutators/#ROR)
-  - [ ] [ROR2](http://pitest.org/quickstart/mutators/#ROR)
+  - [x] [ROR2](http://pitest.org/quickstart/mutators/#ROR)
   - [ ] [ROR3](http://pitest.org/quickstart/mutators/#ROR)
   - [x] [ROR4](http://pitest.org/quickstart/mutators/#ROR)
   - [x] [Remove Conditionals](http://pitest.org/quickstart/mutators/#REMOVE_CONDITIONALS)

--- a/README.md
+++ b/README.md
@@ -27,12 +27,17 @@ The `exavier` library mutates code in **parallel per module**, but mutates each 
 
 ### Mutators
 
-Mutators specify ways in which we can mutate the code. Currently we have 7 proof-of-concept mutators available in `exavier`:
+Mutators specify ways in which we can mutate the code. Currently we have 12 proof-of-concept mutators available in `exavier`:
 
   - [AOR1](https://github.com/dnlserrano/exavier/blob/master/lib/exavier/mutators/aor1.ex)
   - [AOR2](https://github.com/dnlserrano/exavier/blob/master/lib/exavier/mutators/aor2.ex)
+  - [AOR3](https://github.com/dnlserrano/exavier/blob/master/lib/exavier/mutators/aor3.ex)
+  - [AOR4](https://github.com/dnlserrano/exavier/blob/master/lib/exavier/mutators/aor4.ex)
   - [ROR1](https://github.com/dnlserrano/exavier/blob/master/lib/exavier/mutators/ror1.ex)
+  - [ROR2](https://github.com/dnlserrano/exavier/blob/master/lib/exavier/mutators/ror2.ex)
+  - [ROR3](https://github.com/dnlserrano/exavier/blob/master/lib/exavier/mutators/ror3.ex)
   - [ROR4](https://github.com/dnlserrano/exavier/blob/master/lib/exavier/mutators/ror4.ex)
+  - [ROR5](https://github.com/dnlserrano/exavier/blob/master/lib/exavier/mutators/ror5.ex)
   - [IfTrue](https://github.com/dnlserrano/exavier/blob/master/lib/exavier/mutators/if_true.ex)
   - [NegateConditionals](https://github.com/dnlserrano/exavier/blob/master/lib/exavier/mutators/negate_conditionals.ex)
   - [ConditionalsBoundary](https://github.com/dnlserrano/exavier/blob/master/lib/exavier/mutators/conditionals_boundary.ex)

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ This is for now just a proof-of-concept. A lot of it has been no more than a joy
 - [ ] Add mutators
   - [x] [AOR1](http://pitest.org/quickstart/mutators/#AOR)
   - [x] [AOR2](http://pitest.org/quickstart/mutators/#AOR)
-  - [ ] [AOR3](http://pitest.org/quickstart/mutators/#AOR)
+  - [x] [AOR3](http://pitest.org/quickstart/mutators/#AOR)
   - [ ] [AOR4](http://pitest.org/quickstart/mutators/#AOR)
   - [x] [ROR1](http://pitest.org/quickstart/mutators/#ROR)
   - [ ] [ROR2](http://pitest.org/quickstart/mutators/#ROR)

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ This is for now just a proof-of-concept. A lot of it has been no more than a joy
   - [x] [AOR4](http://pitest.org/quickstart/mutators/#AOR)
   - [x] [ROR1](http://pitest.org/quickstart/mutators/#ROR)
   - [x] [ROR2](http://pitest.org/quickstart/mutators/#ROR)
-  - [ ] [ROR3](http://pitest.org/quickstart/mutators/#ROR)
+  - [x] [ROR3](http://pitest.org/quickstart/mutators/#ROR)
   - [x] [ROR4](http://pitest.org/quickstart/mutators/#ROR)
   - [x] [Remove Conditionals](http://pitest.org/quickstart/mutators/#REMOVE_CONDITIONALS)
     - Can still be done for `case`, `unless`

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ This is for now just a proof-of-concept. A lot of it has been no more than a joy
   - [x] [ROR2](http://pitest.org/quickstart/mutators/#ROR)
   - [x] [ROR3](http://pitest.org/quickstart/mutators/#ROR)
   - [x] [ROR4](http://pitest.org/quickstart/mutators/#ROR)
+  - [x] [ROR5](http://pitest.org/quickstart/mutators/#ROR)
   - [x] [Remove Conditionals](http://pitest.org/quickstart/mutators/#REMOVE_CONDITIONALS)
     - Can still be done for `case`, `unless`
   - [x] [Conditionals Boundary](http://pitest.org/quickstart/mutators/#CONDITIONALS_BOUNDARY)

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ This is for now just a proof-of-concept. A lot of it has been no more than a joy
   - [x] [AOR1](http://pitest.org/quickstart/mutators/#AOR)
   - [x] [AOR2](http://pitest.org/quickstart/mutators/#AOR)
   - [x] [AOR3](http://pitest.org/quickstart/mutators/#AOR)
-  - [ ] [AOR4](http://pitest.org/quickstart/mutators/#AOR)
+  - [x] [AOR4](http://pitest.org/quickstart/mutators/#AOR)
   - [x] [ROR1](http://pitest.org/quickstart/mutators/#ROR)
   - [ ] [ROR2](http://pitest.org/quickstart/mutators/#ROR)
   - [ ] [ROR3](http://pitest.org/quickstart/mutators/#ROR)

--- a/lib/exavier/mutators.ex
+++ b/lib/exavier/mutators.ex
@@ -2,7 +2,10 @@ defmodule Exavier.Mutators do
   @mutators [
     __MODULE__.AOR1,
     __MODULE__.AOR2,
+    __MODULE__.AOR3,
+    __MODULE__.AOR4,
     __MODULE__.ROR1,
+    __MODULE__.ROR2,
     __MODULE__.ROR4,
     __MODULE__.IfTrue,
     __MODULE__.NegateConditionals,

--- a/lib/exavier/mutators.ex
+++ b/lib/exavier/mutators.ex
@@ -8,6 +8,7 @@ defmodule Exavier.Mutators do
     __MODULE__.ROR2,
     __MODULE__.ROR3,
     __MODULE__.ROR4,
+    __MODULE__.ROR5,
     __MODULE__.IfTrue,
     __MODULE__.NegateConditionals,
     __MODULE__.ConditionalsBoundary

--- a/lib/exavier/mutators.ex
+++ b/lib/exavier/mutators.ex
@@ -6,6 +6,7 @@ defmodule Exavier.Mutators do
     __MODULE__.AOR4,
     __MODULE__.ROR1,
     __MODULE__.ROR2,
+    __MODULE__.ROR3,
     __MODULE__.ROR4,
     __MODULE__.IfTrue,
     __MODULE__.NegateConditionals,

--- a/lib/exavier/mutators/aor3.ex
+++ b/lib/exavier/mutators/aor3.ex
@@ -1,0 +1,53 @@
+defmodule Exavier.Mutators.AOR3 do
+  @moduledoc """
+  Mutates arithmetic operators into another operation..
+
+  Conditionals are replaced according to the table below.
+
+  | Original | Mutation |
+  |----------|----------|
+  | +        | /        |
+  | -        | /        |
+  | *        | +        |
+  | /        | +        |
+  | rem/2    | +        |
+
+  For example:
+
+      a = b + 5
+
+  will be mutated into
+
+      a = b / 5
+  """
+
+  @behaviour Exavier.Mutators.Mutator
+
+  @mutations %{
+    :+ => :/,
+    :- => :/,
+    :* => :+,
+    :/ => :+,
+    :rem => :+
+  }
+
+  @impl Exavier.Mutators.Mutator
+  def operators, do: Map.keys(@mutations)
+
+  @impl Exavier.Mutators.Mutator
+  def mutate({operator, meta, args}, lines_to_mutate) do
+    mutated_operator = mutate_operator(operator, args)
+    do_mutate({mutated_operator, meta, args}, lines_to_mutate)
+  end
+
+  defp mutate_operator(:-, args) when length(args) == 1, do: :-
+
+  defp mutate_operator(operator, _args), do: @mutations[operator]
+
+  defp do_mutate({nil, _, _}, _), do: :skip
+
+  defp do_mutate({mutated_op, meta, args}, lines_to_mutate) do
+    {_, mutated_args} = Exavier.mutate_all(args, __MODULE__, lines_to_mutate)
+    {mutated_op, meta, mutated_args}
+  end
+end

--- a/lib/exavier/mutators/aor4.ex
+++ b/lib/exavier/mutators/aor4.ex
@@ -1,0 +1,53 @@
+defmodule Exavier.Mutators.AOR4 do
+  @moduledoc """
+  Mutates arithmetic operators into another operation..
+
+  Conditionals are replaced according to the table below.
+
+  | Original | Mutation |
+  |----------|----------|
+  | +        | rem/2    |
+  | -        | rem/2    |
+  | *        | -        |
+  | /        | -        |
+  | rem/2    | -        |
+
+  For example:
+
+      a = b + 5
+
+  will be mutated into
+
+      a = rem(b, 5)
+  """
+
+  @behaviour Exavier.Mutators.Mutator
+
+  @mutations %{
+    :+ => :rem,
+    :- => :rem,
+    :* => :-,
+    :/ => :-,
+    :rem => :-
+  }
+
+  @impl Exavier.Mutators.Mutator
+  def operators, do: Map.keys(@mutations)
+
+  @impl Exavier.Mutators.Mutator
+  def mutate({operator, meta, args}, lines_to_mutate) do
+    mutated_operator = mutate_operator(operator, args)
+    do_mutate({mutated_operator, meta, args}, lines_to_mutate)
+  end
+
+  defp mutate_operator(:-, args) when length(args) == 1, do: :-
+
+  defp mutate_operator(operator, _args), do: @mutations[operator]
+
+  defp do_mutate({nil, _, _}, _), do: :skip
+
+  defp do_mutate({mutated_op, meta, args}, lines_to_mutate) do
+    {_, mutated_args} = Exavier.mutate_all(args, __MODULE__, lines_to_mutate)
+    {mutated_op, meta, mutated_args}
+  end
+end

--- a/lib/exavier/mutators/ror2.ex
+++ b/lib/exavier/mutators/ror2.ex
@@ -1,0 +1,28 @@
+defmodule Exavier.Mutators.ROR2 do
+  @behaviour Exavier.Mutators.Mutator
+
+  @mutations %{
+    :< => :>,
+    :<= => :>,
+    :> => :<=,
+    :>= => :<=,
+    :== => :<=,
+    :!= => :<=
+  }
+
+  @impl Exavier.Mutators.Mutator
+  def operators, do: Map.keys(@mutations)
+
+  @impl Exavier.Mutators.Mutator
+  def mutate({operator, meta, args}, lines_to_mutate) do
+    mutated_operator = @mutations[operator]
+    do_mutate({mutated_operator, meta, args}, lines_to_mutate)
+  end
+
+  defp do_mutate({nil, _, _}, _), do: :skip
+
+  defp do_mutate({mutated_op, meta, args}, lines_to_mutate) do
+    {_, mutated_args} = Exavier.mutate_all(args, __MODULE__, lines_to_mutate)
+    {mutated_op, meta, mutated_args}
+  end
+end

--- a/lib/exavier/mutators/ror2.ex
+++ b/lib/exavier/mutators/ror2.ex
@@ -1,4 +1,26 @@
 defmodule Exavier.Mutators.ROR2 do
+  @moduledoc """
+  Mutates relational operators into another operation.
+
+  Operators are replaced according to the table below.
+
+  | Original | Mutation |
+  |----------|----------|
+  | <        | >        |
+  | <=       | >        |
+  | >        | <=       |
+  | >=       | <=       |
+  | ==       | <=       |
+  | !=       | <=       |
+
+  For example:
+
+      a < 5
+
+  will be mutated into
+
+      a > 5
+  """
   @behaviour Exavier.Mutators.Mutator
 
   @mutations %{

--- a/lib/exavier/mutators/ror3.ex
+++ b/lib/exavier/mutators/ror3.ex
@@ -1,4 +1,27 @@
 defmodule Exavier.Mutators.ROR3 do
+  @moduledoc """
+  Mutates relational operators into another operation.
+
+  Operators are replaced according to the table below.
+
+  | Original | Mutation |
+  |----------|----------|
+  | <        | >=       |
+  | <=       | >=       |
+  | >        | >=       |
+  | >=       | >        |
+  | ==       | >        |
+  | !=       | >        |
+
+  For example:
+
+      a < 5
+
+  will be mutated into
+
+      a >= 5
+  """
+
   @behaviour Exavier.Mutators.Mutator
 
   @mutations %{

--- a/lib/exavier/mutators/ror3.ex
+++ b/lib/exavier/mutators/ror3.ex
@@ -1,0 +1,28 @@
+defmodule Exavier.Mutators.ROR3 do
+  @behaviour Exavier.Mutators.Mutator
+
+  @mutations %{
+    :< => :>=,
+    :<= => :>=,
+    :> => :>=,
+    :>= => :>,
+    :== => :>,
+    :!= => :>
+  }
+
+  @impl Exavier.Mutators.Mutator
+  def operators, do: Map.keys(@mutations)
+
+  @impl Exavier.Mutators.Mutator
+  def mutate({operator, meta, args}, lines_to_mutate) do
+    mutated_operator = @mutations[operator]
+    do_mutate({mutated_operator, meta, args}, lines_to_mutate)
+  end
+
+  defp do_mutate({nil, _, _}, _), do: :skip
+
+  defp do_mutate({mutated_op, meta, args}, lines_to_mutate) do
+    {_, mutated_args} = Exavier.mutate_all(args, __MODULE__, lines_to_mutate)
+    {mutated_op, meta, mutated_args}
+  end
+end

--- a/lib/exavier/mutators/ror5.ex
+++ b/lib/exavier/mutators/ror5.ex
@@ -1,0 +1,28 @@
+defmodule Exavier.Mutators.ROR5 do
+  @behaviour Exavier.Mutators.Mutator
+
+  @mutations %{
+    :< => :!=,
+    :<= => :!=,
+    :> => :!=,
+    :>= => :!=,
+    :== => :!=,
+    :!= => :==
+  }
+
+  @impl Exavier.Mutators.Mutator
+  def operators, do: Map.keys(@mutations)
+
+  @impl Exavier.Mutators.Mutator
+  def mutate({operator, meta, args}, lines_to_mutate) do
+    mutated_operator = @mutations[operator]
+    do_mutate({mutated_operator, meta, args}, lines_to_mutate)
+  end
+
+  defp do_mutate({nil, _, _}, _), do: :skip
+
+  defp do_mutate({mutated_op, meta, args}, lines_to_mutate) do
+    {_, mutated_args} = Exavier.mutate_all(args, __MODULE__, lines_to_mutate)
+    {mutated_op, meta, mutated_args}
+  end
+end

--- a/lib/exavier/mutators/ror5.ex
+++ b/lib/exavier/mutators/ror5.ex
@@ -1,4 +1,26 @@
 defmodule Exavier.Mutators.ROR5 do
+  @moduledoc """
+  Mutates relational operators into another operation.
+
+  Operators are replaced according to the table below.
+
+  | Original | Mutation |
+  |----------|----------|
+  | <        | !=       |
+  | <=       | !=       |
+  | >        | !=       |
+  | >=       | !=       |
+  | ==       | !=       |
+  | !=       | ==       |
+
+  For example:
+
+      a < 5
+
+  will be mutated into
+
+      a != 5
+  """
   @behaviour Exavier.Mutators.Mutator
 
   @mutations %{

--- a/test/exavier/mutators/aor3_test.exs
+++ b/test/exavier/mutators/aor3_test.exs
@@ -1,0 +1,57 @@
+defmodule Exavier.Mutators.AOR3Test do
+  use ExUnit.Case, async: true
+
+  @subject Exavier.Mutators.AOR3
+
+  @mutations [
+    %{
+      description: "mutates + to /",
+      original_code: {:+, [line: 2], [1, 2]},
+      lines_to_mutate: [2],
+      mutated_code: {:/, [line: 2], [1, 2]}
+    },
+    %{
+      description: "mutates - to /",
+      original_code: {:-, [line: 2], [1, 2]},
+      lines_to_mutate: [2],
+      mutated_code: {:/, [line: 2], [1, 2]}
+    },
+    %{
+      description: "mutates * to +",
+      original_code: {:*, [line: 2], [1, 2]},
+      lines_to_mutate: [2],
+      mutated_code: {:+, [line: 2], [1, 2]}
+    },
+    %{
+      description: "mutates / to +",
+      original_code: {:/, [line: 2], [1, 2]},
+      lines_to_mutate: [2],
+      mutated_code: {:+, [line: 2], [1, 2]}
+    },
+    %{
+      description: "mutates rem to +",
+      original_code: {:rem, [line: 2], [1, 2]},
+      lines_to_mutate: [2],
+      mutated_code: {:+, [line: 2], [1, 2]}
+    },
+    %{
+      description: "mutates recursively if operator is repeated",
+      original_code: {:rem, [line: 2], [{:rem, [line: 3], [2, 3]}, 2]},
+      lines_to_mutate: [2, 3],
+      mutated_code: {:+, [line: 2], [{:+, [line: 3], [2, 3]}, 2]}
+    }
+  ]
+
+  @mutations
+  |> Enum.each(fn mutation ->
+    @original_code mutation.original_code
+    @lines_to_mutate mutation.lines_to_mutate
+    @mutated_code mutation.mutated_code
+    @description mutation.description
+
+    test @description do
+      assert @subject.mutate(@original_code, @lines_to_mutate) ==
+               @mutated_code
+    end
+  end)
+end

--- a/test/exavier/mutators/aor4_test.exs
+++ b/test/exavier/mutators/aor4_test.exs
@@ -1,0 +1,57 @@
+defmodule Exavier.Mutators.AOR4Test do
+  use ExUnit.Case, async: true
+
+  @subject Exavier.Mutators.AOR4
+
+  @mutations [
+    %{
+      description: "mutates + to rem",
+      original_code: {:+, [line: 2], [1, 2]},
+      lines_to_mutate: [2],
+      mutated_code: {:rem, [line: 2], [1, 2]}
+    },
+    %{
+      description: "mutates - to rem",
+      original_code: {:-, [line: 2], [1, 2]},
+      lines_to_mutate: [2],
+      mutated_code: {:rem, [line: 2], [1, 2]}
+    },
+    %{
+      description: "mutates * to -",
+      original_code: {:*, [line: 2], [1, 2]},
+      lines_to_mutate: [2],
+      mutated_code: {:-, [line: 2], [1, 2]}
+    },
+    %{
+      description: "mutates / to -",
+      original_code: {:/, [line: 2], [1, 2]},
+      lines_to_mutate: [2],
+      mutated_code: {:-, [line: 2], [1, 2]}
+    },
+    %{
+      description: "mutates rem to -",
+      original_code: {:rem, [line: 2], [1, 2]},
+      lines_to_mutate: [2],
+      mutated_code: {:-, [line: 2], [1, 2]}
+    },
+    %{
+      description: "mutates recursively if operator is repeated",
+      original_code: {:rem, [line: 2], [{:rem, [line: 3], [2, 3]}, 2]},
+      lines_to_mutate: [2, 3],
+      mutated_code: {:-, [line: 2], [{:-, [line: 3], [2, 3]}, 2]}
+    }
+  ]
+
+  @mutations
+  |> Enum.each(fn mutation ->
+    @original_code mutation.original_code
+    @lines_to_mutate mutation.lines_to_mutate
+    @mutated_code mutation.mutated_code
+    @description mutation.description
+
+    test @description do
+      assert @subject.mutate(@original_code, @lines_to_mutate) ==
+               @mutated_code
+    end
+  end)
+end

--- a/test/exavier/mutators/ror2_test.exs
+++ b/test/exavier/mutators/ror2_test.exs
@@ -1,0 +1,63 @@
+defmodule Exavier.Mutators.ROR2Test do
+  use ExUnit.Case, async: true
+
+  @subject Exavier.Mutators.ROR2
+
+  @mutations [
+    %{
+      description: "mutates < to >",
+      original_code: {:<, [line: 2], [1, 2]},
+      lines_to_mutate: [2],
+      mutated_code: {:>, [line: 2], [1, 2]}
+    },
+    %{
+      description: "mutates <= to >",
+      original_code: {:<=, [line: 2], [1, 2]},
+      lines_to_mutate: [2],
+      mutated_code: {:>, [line: 2], [1, 2]}
+    },
+    %{
+      description: "mutates > to <=",
+      original_code: {:>, [line: 2], [1, 2]},
+      lines_to_mutate: [2],
+      mutated_code: {:<=, [line: 2], [1, 2]}
+    },
+    %{
+      description: "mutates >= to <=",
+      original_code: {:>=, [line: 2], [1, 2]},
+      lines_to_mutate: [2],
+      mutated_code: {:<=, [line: 2], [1, 2]}
+    },
+    %{
+      description: "mutates == to <=",
+      original_code: {:==, [line: 2], [1, 2]},
+      lines_to_mutate: [2],
+      mutated_code: {:<=, [line: 2], [1, 2]}
+    },
+    %{
+      description: "mutates != to <=",
+      original_code: {:!=, [line: 2], [1, 2]},
+      lines_to_mutate: [2],
+      mutated_code: {:<=, [line: 2], [1, 2]}
+    },
+    %{
+      description: "mutates recursively if operator is repeated",
+      original_code: {:==, [line: 2], [{:<=, [line: 3], [2, 3]}, false]},
+      lines_to_mutate: [2, 3],
+      mutated_code: {:<=, [line: 2], [{:>, [line: 3], [2, 3]}, false]}
+    }
+  ]
+
+  @mutations
+  |> Enum.each(fn mutation ->
+    @original_code mutation.original_code
+    @lines_to_mutate mutation.lines_to_mutate
+    @mutated_code mutation.mutated_code
+    @description mutation.description
+
+    test @description do
+      assert @subject.mutate(@original_code, @lines_to_mutate) ==
+               @mutated_code
+    end
+  end)
+end

--- a/test/exavier/mutators/ror3_test.exs
+++ b/test/exavier/mutators/ror3_test.exs
@@ -1,0 +1,63 @@
+defmodule Exavier.Mutators.ROR3Test do
+  use ExUnit.Case, async: true
+
+  @subject Exavier.Mutators.ROR3
+
+  @mutations [
+    %{
+      description: "mutates < to >=",
+      original_code: {:<, [line: 2], [1, 2]},
+      lines_to_mutate: [2],
+      mutated_code: {:>=, [line: 2], [1, 2]}
+    },
+    %{
+      description: "mutates <= to >=",
+      original_code: {:<=, [line: 2], [1, 2]},
+      lines_to_mutate: [2],
+      mutated_code: {:>=, [line: 2], [1, 2]}
+    },
+    %{
+      description: "mutates > to >=",
+      original_code: {:>, [line: 2], [1, 2]},
+      lines_to_mutate: [2],
+      mutated_code: {:>=, [line: 2], [1, 2]}
+    },
+    %{
+      description: "mutates >= to >",
+      original_code: {:>=, [line: 2], [1, 2]},
+      lines_to_mutate: [2],
+      mutated_code: {:>, [line: 2], [1, 2]}
+    },
+    %{
+      description: "mutates == to >",
+      original_code: {:==, [line: 2], [1, 2]},
+      lines_to_mutate: [2],
+      mutated_code: {:>, [line: 2], [1, 2]}
+    },
+    %{
+      description: "mutates != to >",
+      original_code: {:!=, [line: 2], [1, 2]},
+      lines_to_mutate: [2],
+      mutated_code: {:>, [line: 2], [1, 2]}
+    },
+    %{
+      description: "mutates recursively if operator is repeated",
+      original_code: {:==, [line: 2], [{:<=, [line: 3], [2, 3]}, false]},
+      lines_to_mutate: [2, 3],
+      mutated_code: {:>, [line: 2], [{:>=, [line: 3], [2, 3]}, false]}
+    }
+  ]
+
+  @mutations
+  |> Enum.each(fn mutation ->
+    @original_code mutation.original_code
+    @lines_to_mutate mutation.lines_to_mutate
+    @mutated_code mutation.mutated_code
+    @description mutation.description
+
+    test @description do
+      assert @subject.mutate(@original_code, @lines_to_mutate) ==
+               @mutated_code
+    end
+  end)
+end

--- a/test/exavier/mutators/ror5_test.exs
+++ b/test/exavier/mutators/ror5_test.exs
@@ -1,0 +1,63 @@
+defmodule Exavier.Mutators.ROR5Test do
+  use ExUnit.Case, async: true
+
+  @subject Exavier.Mutators.ROR5
+
+  @mutations [
+    %{
+      description: "mutates < to !=",
+      original_code: {:<, [line: 2], [1, 2]},
+      lines_to_mutate: [2],
+      mutated_code: {:!=, [line: 2], [1, 2]}
+    },
+    %{
+      description: "mutates <= to !=",
+      original_code: {:<=, [line: 2], [1, 2]},
+      lines_to_mutate: [2],
+      mutated_code: {:!=, [line: 2], [1, 2]}
+    },
+    %{
+      description: "mutates > to !=",
+      original_code: {:>, [line: 2], [1, 2]},
+      lines_to_mutate: [2],
+      mutated_code: {:!=, [line: 2], [1, 2]}
+    },
+    %{
+      description: "mutates >= to !=",
+      original_code: {:>=, [line: 2], [1, 2]},
+      lines_to_mutate: [2],
+      mutated_code: {:!=, [line: 2], [1, 2]}
+    },
+    %{
+      description: "mutates == to !=",
+      original_code: {:==, [line: 2], [1, 2]},
+      lines_to_mutate: [2],
+      mutated_code: {:!=, [line: 2], [1, 2]}
+    },
+    %{
+      description: "mutates != to ==",
+      original_code: {:!=, [line: 2], [1, 2]},
+      lines_to_mutate: [2],
+      mutated_code: {:==, [line: 2], [1, 2]}
+    },
+    %{
+      description: "mutates recursively if operator is repeated",
+      original_code: {:!=, [line: 2], [{:==, [line: 3], [2, 3]}, false]},
+      lines_to_mutate: [2, 3],
+      mutated_code: {:==, [line: 2], [{:!=, [line: 3], [2, 3]}, false]}
+    }
+  ]
+
+  @mutations
+  |> Enum.each(fn mutation ->
+    @original_code mutation.original_code
+    @lines_to_mutate mutation.lines_to_mutate
+    @mutated_code mutation.mutated_code
+    @description mutation.description
+
+    test @description do
+      assert @subject.mutate(@original_code, @lines_to_mutate) ==
+               @mutated_code
+    end
+  end)
+end


### PR DESCRIPTION
Adds AOR 3 & 4, and ROR 2, 3, & 5.

I noticed that ROR5 wasn't on the roadmap. I assumed that was a mistake and added ROR5 anyway. I also added it to the roadmap list.